### PR TITLE
changed macOS shell commands to use ifconfig instead of ip command

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,16 +110,6 @@ You should already have acquired `tch-exploit` for your operating system. If you
         netsh interface ipv4 set address name="Ethernet" static 192.168.0.254 255.255.255.0 192.168.0.1
         tch-exploit-win --ip=192.168.0.254 --tftp=<firmware_file>
         ```
-    * **Mac**: Run the following commands:
-        * _Replace `release` with the name of the directory containing tch-exploit-mac_
-        * _Replace `eth0` with the name of your ethernet connection_
-        * _Replace `<firmware_file>` with the name of the Type 2 firmware you downloaded for your device_
-        * _Each line is one command. Run them separately._
-        ```shell
-        cd release
-        sudo ip addr add 192.168.0.254/24 dev eth0
-        sudo ./tch-exploit-mac --ip=192.168.0.254 --tftp=<firmware_file>
-        ```
     * **Linux**: Run the following commands:
         * _Replace `release` with the name of the directory containing tch-exploit-linux_
         * _Replace `eth0` with the name of your ethernet connection_
@@ -129,6 +119,16 @@ You should already have acquired `tch-exploit` for your operating system. If you
         cd release
         sudo ip addr add 192.168.0.254/24 dev eth0
         sudo ./tch-exploit-linux --ip=192.168.0.254 --tftp=<firmware_file>
+        ```
+    * **Mac**: Run the following commands:
+        * _Replace `release` with the name of the directory containing tch-exploit-mac_
+        * _Replace `eth0` with the name of your ethernet connection_
+        * _Replace `<firmware_file>` with the name of the Type 2 firmware you downloaded for your device_
+        * _Each line is one command. Run them separately._
+        ```shell
+        cd release
+        sudo ifconfig en0 inet 192.168.0.254 netmask 255.255.255.0
+        sudo ./tch-exploit-mac --ip=192.168.0.254 --tftp=<firmware_file>
         ```
 
 #### BOOTP Mode
@@ -154,13 +154,21 @@ If you are using the `seud0nym` version of `tch-exploit`, it will automatically 
     ```dos
     netsh interface ipv4 set address name="Ethernet" dhcp
     ```
-* **Linux/Mac**: Run the following commands:
+* **Linux**: Run the following commands:
     * _Replace `eth0` with the name of your ethernet connection_
     * _Each line is one command. Run them separately._
     ```shell
     sudo ip addr del 192.168.0.254/24 dev eth0
     sudo ifdown eth0
     sudo ifup eth0
+    ```
+* **Mac**: Run the following commands:
+    * _Replace `eth0` with the name of your ethernet connection_
+    * _Each line is one command. Run them separately._
+    ```shell
+    sudo ifconfig en5 inet 192.168.0.254 -alias
+    sudo ifconfig en0 down
+    sudo ifconfig en0 up
     ```
 
 #### Confirm Type 2 Firmware Successfully Booted
@@ -248,13 +256,21 @@ If you are booting a Type 2 firmware (either by default or by loading one via BO
         ```dos
         netsh interface ipv4 set address name="Ethernet" dhcp
         ```
-    * **Linux/Mac**: Run the following commands:
+    * **Linux**: Run the following commands:
         * _Replace `eth0` with the name of your ethernet connection_
         * _Each line is one command. Run them separately._
         ```shell
         sudo ip addr del 58.162.0.1/24 dev eth0
         sudo ifdown eth0
         sudo ifup eth0
+        ```
+    * **Mac**: Run the following commands:
+        * _Replace `eth0` with the name of your ethernet connection_
+        * _Each line is one command. Run them separately._
+        ```shell
+        sudo ifconfig en5 inet 192.168.0.254 -alias
+        sudo ifconfig en0 down
+        sudo ifconfig en0 up
         ```
 
 You can now log in to your device using your SSH client, using a username of `root` and password `root`.


### PR DESCRIPTION
The macOS commands for the changing interfaces is the ```ifconfig``` command by default.
The read me was using the Linux ```ip``` command for macOS instead of ```ifconfig```.
I have updated the read me to include the equivalent ```ifconfig``` commands to the ip commands.